### PR TITLE
feat(manifest): add support After Effects > 17 version

### DIFF
--- a/bundle/CSXS/manifest.xml
+++ b/bundle/CSXS/manifest.xml
@@ -6,8 +6,8 @@
 	</ExtensionList>
 	<ExecutionEnvironment>
 		<HostList>
-            <Host Name="AEFT" Version="[13.0,16.9]" Port="8093" />
-            <Host Name="AEFX" Version="[13.0,16.9]" Port="8093" />
+            <Host Name="AEFT" Version="[13.0,17.9]" Port="8093" />
+            <Host Name="AEFX" Version="[13.0,17.9]" Port="8093" />
 
             <!-- Illustrator -->
             <!-- <Host Name="ILST" Version="[18.0,18.9]" />-->


### PR DESCRIPTION
At the moment, the extension does not support not installing on After Effects 17. But I tested it works on this version and everything works.